### PR TITLE
Uservoice Initial Review

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-uservoice',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_uservoice'],
       install_requires=[
-          'singer-python==5.0.12',
+          'singer-python==5.1.5',
           'backoff==1.3.2',
           'requests==2.18.4',
           'funcy==1.10.1',

--- a/tap_uservoice/__init__.py
+++ b/tap_uservoice/__init__.py
@@ -36,7 +36,7 @@ def get_streams_to_replicate(config, state, catalog, client):
     streams = []
 
     for stream_catalog in catalog.get('streams'):
-        if not is_selected(stream_catalog.get('schema', {})):
+        if not is_selected(stream_catalog):
             LOGGER.info("'{}' is not marked selected, skipping."
                         .format(stream_catalog.get('stream')))
             continue

--- a/tap_uservoice/__init__.py
+++ b/tap_uservoice/__init__.py
@@ -56,7 +56,11 @@ def do_sync(args):
 
     config = load_config(args.config)
     state = load_state(args.state)
-    catalog = load_catalog(args.properties)
+    if args.properties:
+        catalog = load_catalog(args.properties)
+    elif args.catalog:
+        catalog = singer.Catalog.load(args.catalog)
+
     client = UservoiceClient(config)
     client.authorize()
 
@@ -92,6 +96,8 @@ def main():
         '-s', '--state', help='State file')
     parser.add_argument(
         '-p', '--properties', help='Catalog file with fields selected')
+    parser.add_argument(
+        '--catalog', help='Catalog file')
 
     parser.add_argument(
         '-d', '--discover',
@@ -107,7 +113,7 @@ def main():
 
     if args.discover:
         do_discover(args)
-    else:
+    elif args.properties or args.catalog:
         do_sync(args)
 
 

--- a/tap_uservoice/catalog.py
+++ b/tap_uservoice/catalog.py
@@ -1,16 +1,22 @@
 import json
 import singer
+from singer import metadata
 
 LOGGER = singer.get_logger()  # noqa
 
 
-def is_selected(catalog_entry):
-    default = catalog_entry.get('selected-by-default', False)
+def is_selected(stream):
+    # try metadata first
+    mdata = metadata.to_map(stream.get('metadata'))
+    if mdata.get((), {}).get('selected', False):
+        return True
 
-    return ((catalog_entry.get('inclusion') == 'automatic') or
-            (catalog_entry.get('inclusion') == 'available' and
-             catalog_entry.get('selected', default) is True))
-
+    # fallback to legacy way
+    schema = stream.get('schema')
+    default = schema.get('selected-by-default', False)
+    return ((schema.get('inclusion') == 'automatic') or
+            (schema.get('inclusion') == 'available' and
+             schema.get('selected', default) is True))
 
 def load_catalog(filename):
     catalog = {}

--- a/tap_uservoice/streams/base.py
+++ b/tap_uservoice/streams/base.py
@@ -119,10 +119,12 @@ class BaseStream:
                         singer.write_record(table, rec, time_extracted=extraction_time)
                         counter.increment()
 
-                        self.state = incorporate(self.state,
-                                                 table,
-                                                 'updated_at',
-                                                 obj.get('updated_at'))
+                        rec_updated_at = rec.get(self.replication_key)
+                        if rec_updated_at:
+                            self.state = incorporate(self.state,
+                                                     table,
+                                                     self.replication_key,
+                                                     rec_updated_at)
 
                 if page == total_pages:
                     LOGGER.info('Reached end of stream, moving on.')

--- a/tap_uservoice/streams/base.py
+++ b/tap_uservoice/streams/base.py
@@ -16,6 +16,8 @@ class BaseStream:
     # ABSTRACT PROPERTIES -- SHOULD BE OVERRIDDEN
     TABLE = None
     SCHEMA = None
+    replication_key = 'updated_at'
+    replication_method = 'INCREMENTAL'
 
     def get_stream_data(self, result):
         """
@@ -127,7 +129,7 @@ class BaseStream:
 
         self.state = incorporate(self.state,
                                  table,
-                                 'updated_at',
+                                 self.replication_key,
                                  date.isoformat())
 
         save_state(self.state)


### PR DESCRIPTION
Changelist:

- Bumped version of singer-python to latest (5.1.5)
- Accept `--catalog` argument, but defer to `--properties` arg if present
- Make `replication_key` and `replication_method` fields on the `BaseStream` class
- Use metadata to write `table-key-properties`, `forced-replication-method`, `valid-replication-keys`, and `inclusion` (for fields)
- Try metadata for stream selection, otherwise fall back to legacy way
- Use singer-python's transformer to do field selection
- Check for the `replication_key` in the record before bookmarking -- had to do this since the 'teams' stream does not return records with an `updated_at` field