### PR TITLE
FIX: correct properties on external_users stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+  * Fix properties on external_users stream
+
 ## 1.0.2
   * Update version of `requests` to `2.20.0` in response to CVE 2018-18074
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 setup(name='tap-uservoice',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the Uservoice API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_uservoice/streams/external_users.py
+++ b/tap_uservoice/streams/external_users.py
@@ -21,8 +21,8 @@ class ExternalUsersStream(BaseStream):
             "links": {
                 "type": "object",
                 "properties": {
-                    "external_accounts": {"type": ["integer", "null"]},
-                    "external_users": {"type": ["integer", "null"]},
+                    "external_account": {"type": ["integer", "null"]},
+                    "user": {"type": ["integer", "null"]},
                 },
             },
             "name": {"type": ["string", "null"]},


### PR DESCRIPTION
Included properties on `external_users` stream should be 1 `external_account` (not multiple) and 1 `user` (not `external_user`). Tested and verified locally that this is working as expected.