### PR TITLE
Update page number for request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It:
 1. Install
 
 ```bash
-git clone git@github.com:fishtown-analytics/tap-uservoice.git
+git clone git@github.com:singer-io/tap-uservoice.git
 cd tap-uservoice
 pip install .
 ```

--- a/tap_uservoice/streams/base.py
+++ b/tap_uservoice/streams/base.py
@@ -105,6 +105,7 @@ class BaseStream:
                 endpoint=table)
 
             cursor = result.get('pagination', {}).get('cursor')
+            page = result.get('pagination', {}).get('pages')
             total_pages = result.get('pagination', {}).get('total_pages')
             data = self.get_stream_data(result)
             has_data = ((data is not None) and (len(data) > 0))


### PR DESCRIPTION
# Description of change
The UserVoice tap misses results when a stream has over 200 results for a given request. It turns out that this is a problem because the UserVoice result will return a different number of requests on subsequent requests.

For example, say you are working with 138 total records. The first request returns the following pagination information: `{'page': 1, 'per_page': 100, 'total_pages': 2, 'total_records': 138, 'cursor': 'cursor_value'}`

When the next request is made, the pagination information is `{'page': 1, 'per_page': 100, 'total_pages': 1, 'total_records': 38}`; however, currently `page = 2`. This means that `page == total_pages` won't fire and `cursor is None` will. This means that additional data won't be retrieved and records will be missed.

This change pulls the number of pages from the request.

(Additionally, a minor change is made to the README to clone this repo and not the original repo that isn't maintained.)

# Manual QA steps
 - Edit over 100 objects from a given stream on the same day.
 - Set up the UserVoice tap to retrieve those objects.
 - Compare the number of retrieved records to the number of updated objects.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
