### PR TITLE
Use REPLICATION_METHOD instead of REPLICATION_KEY in metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+
+# virtualenv
+venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.0
+## 1.1.1
   * Update metadata to use REPLICATION_METHOD instead of REPLICATION_KEY [#13](https://github.com/singer-io/tap-uservoice/pull/13)
 
 ## 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+  * Update metadata to use REPLICATION_METHOD instead of REPLICATION_KEY [#13](https://github.com/singer-io/tap-uservoice/pull/13)
+
 ## 1.1.0
   * Dependencies updates [#12](https://github.com/singer-io/tap-uservoice/pull/12)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 setup(name='tap-uservoice',
-      version='1.1.0',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Uservoice API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 setup(name='tap-uservoice',
-      version='1.2.0',
+      version='1.1.1',
       description='Singer.io tap for extracting data from the Uservoice API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_uservoice/streams/base.py
+++ b/tap_uservoice/streams/base.py
@@ -45,7 +45,7 @@ class BaseStream:
         mdata = metadata.new()
 
         mdata = metadata.write(mdata, (), 'table-key-properties', cls.KEY_PROPERTIES)
-        mdata = metadata.write(mdata, (), 'forced-replication-method', cls.REPLICATION_KEY)
+        mdata = metadata.write(mdata, (), 'forced-replication-method', cls.REPLICATION_METHOD)
 
         if cls.REPLICATION_KEY:
             mdata = metadata.write(mdata, (), 'valid-replication-keys', [cls.REPLICATION_KEY])


### PR DESCRIPTION
# Description of change
[SAC-28899](https://qlik-dev.atlassian.net/browse/SAC-28899)
Updated code to use REPLICATION_METHOD instead of REPLICATION_KEY in metadata when writing the 'forced-replication-method' field.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
